### PR TITLE
Updated domain for github doc urls

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ dotnet add package DolbyIO.Comms.Sdk
 
 #### 1. Initialize the SDK
 
-Initialize the SDK using the secure authentication method that uses a token in the application. For the purpose of this application, use a [client access token](https://docs.dolby.io/communications-apis/docs/overview-developer-tools#client-access-token) generated from the Dolby.io dashboard. Use the following code to initialize the SDK using the [DolbyIOSDK.InitAsync](https://dolbyio.github.io/comms-sdk-dotnet/documentation/api/DolbyIO.Comms.DolbyIOSDK.html#DolbyIO_Comms_DolbyIOSDK_InitAsync_System_String_DolbyIO_Comms_RefreshTokenCallBack_) method:
+Initialize the SDK using the secure authentication method that uses a token in the application. For the purpose of this application, use a [client access token](https://docs.dolby.io/communications-apis/docs/overview-developer-tools#client-access-token) generated from the Dolby.io dashboard. Use the following code to initialize the SDK using the [DolbyIOSDK.InitAsync](https://api-references.dolby.io/comms-sdk-dotnet/documentation/api/DolbyIO.Comms.DolbyIOSDK.html#DolbyIO_Comms_DolbyIOSDK_InitAsync_System_String_DolbyIO_Comms_RefreshTokenCallBack_) method:
 
 ```cs
 using DolbyIO.Comms;
@@ -58,7 +58,7 @@ catch (DolbyIOException e)
 }
 ```
 
-**NOTE:** The SDK is fully asynchronous, and all methods can throw the [DolbyIOException](https://dolbyio.github.io/comms-sdk-dotnet/documentation/api/DolbyIO.Comms.DolbyIOException.html).
+**NOTE:** The SDK is fully asynchronous, and all methods can throw the [DolbyIOException](https://api-references.dolby.io/comms-sdk-dotnet/documentation/api/DolbyIO.Comms.DolbyIOException.html).
 
 #### 2. Register event handlers
 
@@ -82,7 +82,7 @@ _sdk.Conference.ParticipantAdded = new ParticipantAddedEventHandler
 
 A session is a connection between the client application and the Dolby.io backend. When opening a session, you should provide a name. Commonly, this is the name of the participant who established the session. The session can remain active for the whole lifecycle of your application. 
 
-To open a new session, use the [Session.OpenAsync](https://dolbyio.github.io/comms-sdk-dotnet/documentation/api/DolbyIO.Comms.Services.SessionService.html#DolbyIO_Comms_Services_SessionService_OpenAsync_DolbyIO_Comms_UserInfo_) method as in the following example:
+To open a new session, use the [Session.OpenAsync](https://api-references.dolby.io/comms-sdk-dotnet/documentation/api/DolbyIO.Comms.Services.SessionService.html#DolbyIO_Comms_Services_SessionService_OpenAsync_DolbyIO_Comms_UserInfo_) method as in the following example:
 
 ```cs
 try
@@ -102,7 +102,7 @@ catch (DolbyIOException e)
 
 A conference is a multi-person call where participants exchange audio with one another. To distinguish between multiple conferences, you should assign a conference alias or name. When multiple participants join a conference of the same name using a token of the same Dolby.io application, they will be able to meet in a call.
 
-To create and join a conference, use the [Conference.CreateAsync](hhttps://dolbyio.github.io/comms-sdk-dotnet/documentation/api/DolbyIO.Comms.Services.ConferenceService.html#DolbyIO_Comms_Services_ConferenceService_CreateAsync_DolbyIO_Comms_ConferenceOptions_) and [Conference.JoinAsync](https://dolbyio.github.io/comms-sdk-dotnet/documentation/api/DolbyIO.Comms.Services.ConferenceService.html#DolbyIO_Comms_Services_ConferenceService_JoinAsync_DolbyIO_Comms_Conference_DolbyIO_Comms_JoinOptions_) methods as in the following example:
+To create and join a conference, use the [Conference.CreateAsync](hhttps://api-references.dolby.io/comms-sdk-dotnet/documentation/api/DolbyIO.Comms.Services.ConferenceService.html#DolbyIO_Comms_Services_ConferenceService_CreateAsync_DolbyIO_Comms_ConferenceOptions_) and [Conference.JoinAsync](https://api-references.dolby.io/comms-sdk-dotnet/documentation/api/DolbyIO.Comms.Services.ConferenceService.html#DolbyIO_Comms_Services_ConferenceService_JoinAsync_DolbyIO_Comms_Conference_DolbyIO_Comms_JoinOptions_) methods as in the following example:
 
 ```cs
 try
@@ -121,11 +121,11 @@ catch (DolbyIOException e)
 }
 ```
 
-If the conference already exists, the SDK returns [Conference](https://dolbyio.github.io/comms-sdk-dotnet/documentation/api/DolbyIO.Comms.Conference).
+If the conference already exists, the SDK returns [Conference](https://api-references.dolby.io/comms-sdk-dotnet/documentation/api/DolbyIO.Comms.Conference).
 
 #### 5. Leave the conference
 
-To leave the conference, use the [Conference.LeaveAsync](https://dolbyio.github.io/comms-sdk-dotnet/documentation/api/DolbyIO.Comms.Services.ConferenceService.html#DolbyIO_Comms_Services_ConferenceService_LeaveAsync) method, as in the following example:
+To leave the conference, use the [Conference.LeaveAsync](https://api-references.dolby.io/comms-sdk-dotnet/documentation/api/DolbyIO.Comms.Services.ConferenceService.html#DolbyIO_Comms_Services_ConferenceService_LeaveAsync) method, as in the following example:
 
 ```cs
 try
@@ -140,7 +140,7 @@ catch (DolbyIOException e)
 
 #### 6. Close the session and dispose of the SDK
 
-After leaving the conference, close the session and dispose the SDK using the [Session.CloseAsync](https://dolbyio.github.io/comms-sdk-dotnet/documentation/api/DolbyIO.Comms.Services.SessionService.html#DolbyIO_Comms_Services_SessionService_CloseAsync) and [DolbyIOSDK.Dispose](https://dolbyio.github.io/comms-sdk-dotnet/documentation/api/DolbyIO.Comms.DolbyIOSDK.html#DolbyIO_Comms_DolbyIOSDK_Dispose) methods.
+After leaving the conference, close the session and dispose the SDK using the [Session.CloseAsync](https://api-references.dolby.io/comms-sdk-dotnet/documentation/api/DolbyIO.Comms.Services.SessionService.html#DolbyIO_Comms_Services_SessionService_CloseAsync) and [DolbyIOSDK.Dispose](https://api-references.dolby.io/comms-sdk-dotnet/documentation/api/DolbyIO.Comms.DolbyIOSDK.html#DolbyIO_Comms_DolbyIOSDK_Dispose) methods.
 
 ```cs
 try

--- a/cmake/package.json.in
+++ b/cmake/package.json.in
@@ -3,7 +3,7 @@
   "version": "${PROJECT_VERSION}",
   "displayName": "DolbyIO .NET Sdk",
   "description": "The DolbyIO .NET Sdk",
-  "documentationUrl": "https://dolbyio.github.io/comms-sdk-dotnet/documentation/index.html",
+  "documentationUrl": "https://api-references.dolby.io/comms-sdk-dotnet/documentation/index.html",
   "licensesUrl": "https://github.com/DolbyIO/comms-sdk-dotnet/blob/main/LICENSE",
   "dependencies": {
 


### PR DESCRIPTION
Updated to custom domain for doc links -> https://api-references.dolby.io/